### PR TITLE
Click away closes cart

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "express": "^4.17.1",
     "pg": "^8.5.1",
     "react": "^17.0.1",
+    "react-click-away-listener": "^2.0.0",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
     "stripe": "^8.138.0",

--- a/public/components/Cart.js
+++ b/public/components/Cart.js
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import ClickAwayListener from "react-click-away-listener";
 import { CartContext } from "../context/CartContext";
 import { UserContext } from "../context/UserContext";
 import { LocaleContext } from "../context/LocaleContext";
@@ -103,7 +104,7 @@ const Currency = styled.span`
 `;
 
 const Cart = ({ open }) => {
-  const { items, setCartVisible } = React.useContext(CartContext);
+  const { items, cartVisible, setCartVisible } = React.useContext(CartContext);
   const { userEmail, userID } = React.useContext(UserContext);
   const { selectedLocale } = React.useContext(LocaleContext);
   const [showCartShadow, setShowCartShadow] = React.useState(false);
@@ -128,11 +129,18 @@ const Cart = ({ open }) => {
 
   React.useEffect(showShadowIfMoreCartItems);
 
+  const handleClickAway = (event) => {
+    const isClickOnAddToOrderButton = !!event.target.closest(".add-to-order");
+    if (cartVisible && !isClickOnAddToOrderButton) {
+      setCartVisible(false);
+    }
+  };
+
   let grandTotal = 0;
   items.forEach((item) => (grandTotal += item.price * item.quantity));
 
   return (
-    <>
+    <ClickAwayListener onClickAway={handleClickAway}>
       <Dialog open={open}>
         <CartTop onScroll={showShadowIfMoreCartItems} ref={cartTop}>
           {items.map((item) => (
@@ -163,7 +171,7 @@ const Cart = ({ open }) => {
           </CheckoutButton>
         </CartBottom>
       </Dialog>
-    </>
+    </ClickAwayListener>
   );
 };
 

--- a/public/components/Item.js
+++ b/public/components/Item.js
@@ -92,6 +92,7 @@ const Item = ({ name, image, lqip, id, price, calories }) => {
           variant="primary"
           size="md"
           onClick={() => addToCart({ name, image, price, id })}
+          className="add-to-order"
         >
           <span>Add to order</span>
           <Price>{displayPrice}</Price>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5347,6 +5347,11 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+react-click-away-listener@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-click-away-listener/-/react-click-away-listener-2.0.0.tgz#b70e4b87f8529fef2ce658469f415f15fc689c83"
+  integrity sha512-tD32K4usq0v+JWgeP+8B2B84rSR8Gcvs92cnBvlZkkBrgjVWetQUuMCN7De3vyZ36UcOG97JOvWGevyTMEHtdw==
+
 react-dom@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"


### PR DESCRIPTION
closes #94 

I found this cool library that does the trick: https://www.npmjs.com/package/react-click-away-listener

Problem was, we want the cart to still stay open when a user clicks the add to order button.  

So I added a class on that button and only close the case if the click is not on the button.

Good example of how we occasionally have to use our manual dom querying techniques together with react.